### PR TITLE
Move over command definitions from learning-os-software

### DIFF
--- a/config/commands/cycle.yaml
+++ b/config/commands/cycle.yaml
@@ -7,14 +7,14 @@ command:
   commands:
     -
       name: launch
-      description: tally votes and create project teams
+      description: Tally votes and create project teams.
       usage: launch [options]
     -
       name: retro
-      description: initiate retrospective process
-      usage: launch [options]
+      description: Initiate retrospective process.
+      usage: retro [options]
     -
       name: status
-      description: display status information for the cycle
-      usage: launch [options]
+      description: Display status information for the cycle.
+      usage: status [options]
       _inactive: true

--- a/config/commands/goal.yaml
+++ b/config/commands/goal.yaml
@@ -1,0 +1,26 @@
+%YAML 1.2
+---
+command:
+  name: goal
+  description: manage goals
+  usage: goal [options] <command>
+  commands:
+    -
+      name: show
+      description: Show a particular goal.
+      usage: show <id>
+      _inactive: true
+      examples:
+        -
+          example: goal show 12
+          description: Show goal with id 12.
+    -
+      name: create
+      description: Create a new goal.
+      usage: create [<title>]
+      _inactive: true
+    -
+      name: search
+      description: Search for goals by title.
+      usage: search <query>
+      _inactive: true

--- a/config/commands/learner.yaml
+++ b/config/commands/learner.yaml
@@ -1,0 +1,29 @@
+%YAML 1.2
+---
+command:
+  name: learner
+  description: manage learners
+  usage: learner [options] <command>
+  commands:
+    -
+      name: status
+      description: Check status of a learner.
+      usage: status [<@handle>]
+      _inactive: true
+      examples:
+        -
+          example: learner status
+          description: View your own status.
+        -
+          example: learner status @jaime
+          description: View status of learner with handle @jaime.
+    -
+      name: play
+      description: Activate learner for current cycle.
+      usage: play <@handle>
+      _inactive: true
+    -
+      name: pause
+      description: Deactivate learner for current cycle.
+      usage: pause <@handle>
+      _inactive: true

--- a/config/commands/log.yaml
+++ b/config/commands/log.yaml
@@ -8,4 +8,14 @@ command:
     -
       name: reflection
       abbr: r
-      help: Without a number argument, show list of retrospective questions for reflection. With a number, log a reflection for the question corresponding to the number.
+      help: Without a number argument, show list of retrospective questions for reflection. Provide a number to show the reflection question, and to log a reflection for the question.
+  examples:
+    -
+      example: log -r
+      description: Show retrospective status and questions.
+    -
+      example: log -r2
+      description: Show retrospective question number 2.
+    -
+      example: log -r2 "So far so good"
+      description: Answer retrospective question 2 with a reflection message.

--- a/config/commands/log.yaml
+++ b/config/commands/log.yaml
@@ -2,7 +2,7 @@
 ---
 command:
   name: log
-  description: Log reflections.
+  description: log reflections
   usage: log [-r | -r<num> <...reflection>]
   options:
     -

--- a/config/commands/profile.yaml
+++ b/config/commands/profile.yaml
@@ -3,4 +3,4 @@
 command:
   name: profile
   description: edit your user profile
-  usage: 'profile [options]'
+  usage: profile [options]

--- a/config/commands/project.yaml
+++ b/config/commands/project.yaml
@@ -1,0 +1,35 @@
+%YAML 1.2
+---
+command:
+  name: project
+  description: manage projects
+  usage: project [options] <command>
+  commands:
+    -
+      name: status
+      description: Check status of a project.
+      usage: status <id>
+      _inactive: true
+      examples:
+        -
+          example: 'project status #bad-lemurs-12'
+          description: 'View status of project with id #bad-lemurs-12.'
+    -
+      name: show
+      description: Show a particular project.
+      usage: show <id>
+      _inactive: true
+      examples:
+        -
+          example: 'project show #bad-lemurs-12'
+          description: 'Show project with id #bad-lemurs-12.'
+    -
+      name: list
+      description: List all active projects.
+      usage: list
+      _inactive: true
+    -
+      name: search
+      description: Search for projects by title.
+      usage: search <query>
+      _inactive: true


### PR DESCRIPTION
Adds several YAML command config files, all inactive, from the original UX design in learning-os-software.

Fixes LearnersGuild/learning-os-software#88