### PR TITLE
Don't send "API Invocation Failed" in the error messages.

### DIFF
--- a/lib/commands/cycle.js
+++ b/lib/commands/cycle.js
@@ -43,7 +43,7 @@ function invokeUpdateCycleStateAPI(state, lgJWT) {
     variables: { state: state }
   };
   return (0, _graphQLFetcher2.default)(lgJWT, (0, _getServiceBaseURL2.default)(_getServiceBaseURL.GAME))(mutation).then(function (data) {
-    return data.launchCycle;
+    return data.updateCycleState;
   });
 }
 

--- a/lib/commands/cycle.js
+++ b/lib/commands/cycle.js
@@ -59,7 +59,7 @@ function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {
   notify(formatMessage(statusMsg));
   return invokeUpdateCycleStateAPI(state, lgJWT).catch(function (error) {
     _errorReporter2.default.captureException(error);
-    notify(formatError('API invocation failed: ' + (error.message || error)));
+    notify(formatError(error.message || error));
   });
 }
 

--- a/lib/commands/log/LogRetroCommand.js
+++ b/lib/commands/log/LogRetroCommand.js
@@ -114,7 +114,7 @@ var LogRetroCommand = function () {
         return _this3.notifyMsg('Reflection logged for question ' + questionNumber);
       }).catch(function (error) {
         _errorReporter2.default.captureException(error);
-        _this3.notifyError('API invocation failed: ' + (error.message || error));
+        _this3.notifyError(error.message || error);
       });
     }
   }]);

--- a/lib/commands/vote.js
+++ b/lib/commands/vote.js
@@ -66,7 +66,7 @@ function voteForGoals(goalDescriptors, notify, options) {
   notify(formatMessage('Validating the goals you voted on: ' + goalDescriptors.join(', ')));
   return invokeVoteAPI(lgJWT, goalDescriptors).catch(function (error) {
     _errorReporter2.default.captureException(error);
-    notify(formatError('API invocation failed: ' + (error.message || error)));
+    notify(formatError(error.message || error));
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "0.8.1",
+  "version": "0.8.2",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/__tests__/cycle.test.js
+++ b/src/commands/__tests__/cycle.test.js
@@ -11,9 +11,7 @@ describe(testContext(__filename), function () {
       this.notify = msg => {
         this.notifications.push(msg)
       }
-      this.formatError = msg => {
-        this.errors.push(msg)
-      }
+      this.formatError = msg => `__FMT: ${msg}`
       this.lgJWT = 'not.a.real.token'
       this.lgUser = {roles: ['moderator']}
     })
@@ -55,7 +53,7 @@ describe(testContext(__filename), function () {
     it('notifies that the state is being initiated', function () {
       nock('http://game.learnersguild.test')
         .post('/graphql')
-        .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
+        .reply(200, {data: {updateCycleState: {id: '00000000-1111-2222-3333-444444444444'}}})
 
       const {lgJWT, lgUser} = this
       return this.invoke(['reflect'], this.notify, {lgJWT, lgUser})
@@ -67,7 +65,7 @@ describe(testContext(__filename), function () {
     it('does not notify if the API invocation succeeds', function (done) {
       nock('http://game.learnersguild.test')
         .post('/graphql')
-        .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
+        .reply(200, {data: {updateCycleState: {id: '00000000-1111-2222-3333-444444444444'}}})
 
       const {lgJWT, lgUser} = this
       this.invoke(['launch'], this.notify, {lgJWT, lgUser})
@@ -86,7 +84,21 @@ describe(testContext(__filename), function () {
       const {lgJWT, lgUser, formatError} = this
       this.invoke(['reflect'], this.notify, {lgJWT, lgUser, formatError})
         .then(() => {
-          expect(this.errors.length).to.equal(1)
+          expect(this.notifications[1]).to.equal('__FMT: Internal Server Error')
+          done()
+        })
+        .catch(error => done(error))
+    })
+
+    it('notifies of GraphQL invocation errors', function (done) {
+      nock('http://game.learnersguild.test')
+        .post('/graphql')
+        .reply(200, {errors: [{message: 'GraphQL Error'}]})
+
+      const {lgJWT, lgUser, formatError} = this
+      this.invoke(['reflect'], this.notify, {lgJWT, lgUser, formatError})
+        .then(() => {
+          expect(this.notifications[1]).to.equal('__FMT: GraphQL Error')
           done()
         })
         .catch(error => done(error))

--- a/src/commands/__tests__/cycle.test.js
+++ b/src/commands/__tests__/cycle.test.js
@@ -11,10 +11,14 @@ describe(testContext(__filename), function () {
       this.notify = msg => {
         this.notifications.push(msg)
       }
+      this.formatError = msg => {
+        this.errors.push(msg)
+      }
       this.lgJWT = 'not.a.real.token'
       this.lgUser = {roles: ['moderator']}
     })
     beforeEach(function () {
+      this.errors = []
       this.notifications = []
     })
 
@@ -79,10 +83,10 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(500, 'Internal Server Error')
 
-      const {lgJWT, lgUser} = this
-      this.invoke(['reflect'], this.notify, {lgJWT, lgUser})
+      const {lgJWT, lgUser, formatError} = this
+      this.invoke(['reflect'], this.notify, {lgJWT, lgUser, formatError})
         .then(() => {
-          expect(this.notifications[1]).to.match(/API invocation failed/)
+          expect(this.errors.length).to.equal(1)
           done()
         })
         .catch(error => done(error))

--- a/src/commands/__tests__/log.test.js
+++ b/src/commands/__tests__/log.test.js
@@ -11,6 +11,9 @@ describe(testContext(__filename), function () {
       this.notify = msg => {
         this.notifications.push(msg)
       }
+      this.formatError = msg => {
+        this.errors.push(msg)
+      }
       this.argv = ['-rq', '1', 'some1:25', 'some2:25', 'some3:25', 'some4:25']
       this.lgJWT = 'not.a.real.token'
       this.lgPlayer = {id: 'not.a.real.id'}
@@ -18,6 +21,7 @@ describe(testContext(__filename), function () {
 
     beforeEach(function () {
       this.notifications = []
+      this.errors = []
     })
 
     afterEach(function () {
@@ -160,10 +164,10 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(500, 'Internal Server Error')
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['--retro', '--question', '99999999', 'answer'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgPlayer, formatError} = this
+      return this.invoke(['--retro', '--question', '99999999', 'answer'], this.notify, {lgJWT, lgPlayer, formatError})
         .then(() => {
-          expect(this.notifications[0]).to.match(/API invocation failed/)
+          expect(this.errors.length).to.equal(1)
           done()
         })
         .catch(error => done(error))

--- a/src/commands/__tests__/vote.test.js
+++ b/src/commands/__tests__/vote.test.js
@@ -11,15 +11,12 @@ describe(testContext(__filename), function () {
       this.notify = msg => {
         this.notifications.push(msg)
       }
-      this.formatError = msg => {
-        this.errors.push(msg)
-      }
+      this.formatError = msg => `__FMT: ${msg}`
       this.lgJWT = 'not.a.real.token'
       this.lgPlayer = {id: 'not.a.real.id'}
     })
     beforeEach(function () {
       this.notifications = []
-      this.errors = []
     })
 
     it('notifies with the usage message when requested', function () {
@@ -110,7 +107,21 @@ describe(testContext(__filename), function () {
       const {lgJWT, lgPlayer, formatError} = this
       return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer, formatError})
         .then(() => {
-          expect(this.errors.length).to.equal(1)
+          expect(this.notifications[1]).to.equal('__FMT: Internal Server Error')
+          done()
+        })
+        .catch(error => done(error))
+    })
+
+    it('notifies of GraphQL invocation errors', function (done) {
+      nock('http://game.learnersguild.test')
+        .post('/graphql')
+        .reply(200, {errors: [{message: 'GraphQL Error'}]})
+
+      const {lgJWT, lgPlayer, formatError} = this
+      this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer, formatError})
+        .then(() => {
+          expect(this.notifications[1]).to.equal('__FMT: GraphQL Error')
           done()
         })
         .catch(error => done(error))

--- a/src/commands/__tests__/vote.test.js
+++ b/src/commands/__tests__/vote.test.js
@@ -11,11 +11,15 @@ describe(testContext(__filename), function () {
       this.notify = msg => {
         this.notifications.push(msg)
       }
+      this.formatError = msg => {
+        this.errors.push(msg)
+      }
       this.lgJWT = 'not.a.real.token'
       this.lgPlayer = {id: 'not.a.real.id'}
     })
     beforeEach(function () {
       this.notifications = []
+      this.errors = []
     })
 
     it('notifies with the usage message when requested', function () {
@@ -103,10 +107,10 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(500, 'Internal Server Error')
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgPlayer, formatError} = this
+      return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer, formatError})
         .then(() => {
-          expect(this.notifications[1]).to.match(/API invocation failed/)
+          expect(this.errors.length).to.equal(1)
           done()
         })
         .catch(error => done(error))

--- a/src/commands/cycle.js
+++ b/src/commands/cycle.js
@@ -12,7 +12,7 @@ function invokeUpdateCycleStateAPI(state, lgJWT) {
     variables: {state},
   }
   return graphQLFetcher(lgJWT, getServiceBaseURL(GAME))(mutation)
-    .then(data => data.launchCycle)
+    .then(data => data.updateCycleState)
 }
 
 function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {

--- a/src/commands/cycle.js
+++ b/src/commands/cycle.js
@@ -29,7 +29,7 @@ function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {
   return invokeUpdateCycleStateAPI(state, lgJWT)
     .catch(error => {
       errorReporter.captureException(error)
-      notify(formatError(`API invocation failed: ${error.message || error}`))
+      notify(formatError(error.message || error))
     })
 }
 

--- a/src/commands/log/LogRetroCommand.js
+++ b/src/commands/log/LogRetroCommand.js
@@ -106,7 +106,7 @@ export default class LogRetroCommand {
       .then(() => this.notifyMsg(`Reflection logged for question ${questionNumber}`))
       .catch(error => {
         errorReporter.captureException(error)
-        this.notifyError(`API invocation failed: ${error.message || error}`)
+        this.notifyError(error.message || error)
       })
   }
 }

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -42,7 +42,7 @@ function voteForGoals(goalDescriptors, notify, options) {
   return invokeVoteAPI(lgJWT, goalDescriptors)
     .catch(error => {
       errorReporter.captureException(error)
-      notify(formatError(`API invocation failed: ${error.message || error}`))
+      notify(formatError(error.message || error))
     })
 }
 


### PR DESCRIPTION
These messages end up getting propagated to the end-user (who doesn't care that an API was invoked -- they only care about the actual error message).