### PR TITLE
Fix TypeError occurring after failed `/cycle init` attempt

### DIFF
--- a/src/commands/cycle.js
+++ b/src/commands/cycle.js
@@ -35,11 +35,11 @@ function handleCycleInitCommand(notify, options) {
   }
 
   return invokeCreateCycleAPI(lgJWT)
+    .then(cycle => notify(formatMessage(`Cycle #${cycle.cycleNumber} Initialized. Let the voting commence...`)))
     .catch(error => {
       errorReporter.captureException(error)
       notify(formatError(error.message || error))
     })
-    .then(cycle => notify(formatMessage(`Cycle #${cycle.cycleNumber} Initialized. Let the voting commence...`)))
 }
 
 function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {


### PR DESCRIPTION
Fixes https://github.com/LearnersGuild/echo-chat/issues/17.

- Reorders promise chain in `/cycle init` handler