### PR TITLE
command-prefix and line wrapping

### DIFF
--- a/lib/runner.js
+++ b/lib/runner.js
@@ -28,7 +28,7 @@ function getUserOptions() {
 
 function run(commandAndArgv) {
   process.env.APP_BASE_URL = 'https://game-cli.learnersguild.org';
-  var options = getUserOptions();
+  var options = Object.assign({}, getUserOptions(), { maxWidth: process.stdout.columns });
   if (!options) {
     console.error('*** Error: No Learners Guild RC file found in ' + LGRC_FILENAME + ' -- try creating one.');
     return Promise.resolve(1);

--- a/lib/util/composeInvoke.js
+++ b/lib/util/composeInvoke.js
@@ -21,7 +21,10 @@ function composeInvoke(parse, usage, invokeFn) {
   (0, _assertFunctions2.default)({ parse: parse, usage: usage, invokeFn: invokeFn });
   return function (argv, notify) {
     var options = arguments.length <= 2 || arguments[2] === undefined ? {} : arguments[2];
+    var commandPrefix = options.commandPrefix;
+    var maxWidth = options.maxWidth;
 
+    var subcliOpts = { commandPrefix: commandPrefix, maxWidth: maxWidth };
     var opts = Object.assign({}, _defaultInvokeOptions2.default, options);
     var formatMessage = opts.formatMessage;
     var formatError = opts.formatError;
@@ -30,12 +33,12 @@ function composeInvoke(parse, usage, invokeFn) {
     var args = void 0;
     try {
       (0, _assertFunctions2.default)({ notify: notify, formatMessage: formatMessage, formatError: formatError, formatUsage: formatUsage });
-      args = parse(argv);
-    } catch (error) {
-      notify(formatError(error.message || error));
+      args = parse(argv, subcliOpts);
+    } catch (err) {
+      notify(formatError(err.message || err));
       return Promise.resolve();
     }
-    var usageText = usage(args);
+    var usageText = usage(args, subcliOpts);
     if (usageText) {
       notify(formatUsage(usageText));
       return Promise.resolve();
@@ -46,10 +49,10 @@ function composeInvoke(parse, usage, invokeFn) {
       if (typeof promise.then !== 'function') {
         console.error(PROMISE_EXPECTATION_MESSAGE);
       }
-      return promise.catch(function (error) {
-        notify(formatError(error.message || error));
+      return promise.catch(function (err) {
+        notify(formatError(err.message || err));
       });
-    } catch (error) {
+    } catch (err) {
       console.log(PROMISE_EXPECTATION_MESSAGE);
     }
   };

--- a/lib/util/loadCommand.js
+++ b/lib/util/loadCommand.js
@@ -50,11 +50,13 @@ function loadCommand(commandName) {
   return {
     commandDescriptor: commandDescriptor,
     parse: function parse(argv) {
-      return (0, _subcli.parse)(commandDescriptor, argv);
+      var opts = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+      return (0, _subcli.parse)(commandDescriptor, argv, opts);
     },
     usage: function usage() {
       var args = arguments.length <= 0 || arguments[0] === undefined ? null : arguments[0];
-      return (0, _subcli.usage)(commandDescriptor, args);
+      var opts = arguments.length <= 1 || arguments[1] === undefined ? {} : arguments[1];
+      return (0, _subcli.usage)(commandDescriptor, args, opts);
     }
   };
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {
@@ -30,7 +30,7 @@
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "raven": "^0.11.0",
-    "subcli": "^0.1.5",
+    "subcli": "^0.2.1",
     "yamljs": "^0.2.7"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "isomorphic-fetch": "^2.2.1",
     "raven": "^0.11.0",
-    "subcli": "^0.2.1",
+    "subcli": "^0.2.2",
     "yamljs": "^0.2.7"
   },
   "devDependencies": {

--- a/src/runner.js
+++ b/src/runner.js
@@ -17,7 +17,7 @@ function getUserOptions() {
 
 function run(commandAndArgv) {
   process.env.APP_BASE_URL = 'https://game-cli.learnersguild.org'
-  const options = getUserOptions()
+  const options = Object.assign({}, getUserOptions(), {maxWidth: process.stdout.columns})
   if (!options) {
     console.error(`*** Error: No Learners Guild RC file found in ${LGRC_FILENAME} -- try creating one.`)
     return Promise.resolve(1)

--- a/src/util/composeInvoke.js
+++ b/src/util/composeInvoke.js
@@ -6,6 +6,11 @@ const PROMISE_EXPECTATION_MESSAGE = "Warning: invoke function passed to composeI
 export default function composeInvoke(parse, usage, invokeFn) {
   assertFunctions({parse, usage, invokeFn})
   return (argv, notify, options = {}) => {
+    const {
+      commandPrefix,
+      maxWidth,
+    } = options
+    const subcliOpts = {commandPrefix, maxWidth}
     const opts = Object.assign({}, defaultInvokeOptions, options)
     const {
       formatMessage,
@@ -15,12 +20,12 @@ export default function composeInvoke(parse, usage, invokeFn) {
     let args
     try {
       assertFunctions({notify, formatMessage, formatError, formatUsage})
-      args = parse(argv)
-    } catch (error) {
-      notify(formatError(error.message || error))
+      args = parse(argv, subcliOpts)
+    } catch (err) {
+      notify(formatError(err.message || err))
       return Promise.resolve()
     }
-    const usageText = usage(args)
+    const usageText = usage(args, subcliOpts)
     if (usageText) {
       notify(formatUsage(usageText))
       return Promise.resolve()
@@ -31,10 +36,10 @@ export default function composeInvoke(parse, usage, invokeFn) {
       if (typeof promise.then !== 'function') {
         console.error(PROMISE_EXPECTATION_MESSAGE)
       }
-      return promise.catch(error => {
-        notify(formatError(error.message || error))
+      return promise.catch(err => {
+        notify(formatError(err.message || err))
       })
-    } catch (error) {
+    } catch (err) {
       console.log(PROMISE_EXPECTATION_MESSAGE)
     }
   }

--- a/src/util/loadCommand.js
+++ b/src/util/loadCommand.js
@@ -33,7 +33,7 @@ export default function loadCommand(commandName) {
   commandDescriptor = filterOutInactiveSubcommandDescriptors(commandDescriptor)
   return {
     commandDescriptor,
-    parse: argv => parseFor(commandDescriptor, argv),
-    usage: (args = null) => usageFor(commandDescriptor, args),
+    parse: (argv, opts = {}) => parseFor(commandDescriptor, argv, opts),
+    usage: (args = null, opts = {}) => usageFor(commandDescriptor, args, opts),
   }
 }


### PR DESCRIPTION
Fixes #55 

When printing usage / help messages for commands, it's awkward that when the help messages or examples are too long, they don't wrap-and-indent properly.

It's also awkward that within echo no `/` is displayed before the command when the help is printed.

This PR addresses those two issues.