### PR TITLE
remove `/log`, add `/retro`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,14 @@
 # History
 
+#### 0.14.0
+- add `/retro` command
+- remove `/log` command
+
 #### 0.13.2
 - bump subcli to 0.2.3
 
 #### 0.13.2
-- fixup /vote usage
+- fixup `/vote` usage
 
 #### 0.13.0
 - Added support for specifying project name in `/log` commands

--- a/config/commands/goal.yaml
+++ b/config/commands/goal.yaml
@@ -2,6 +2,7 @@
 ---
 command:
   name: goal
+  _inactive: true
   description: manage goals
   usage: goal [options] <command>
   commands:

--- a/config/commands/learner.yaml
+++ b/config/commands/learner.yaml
@@ -2,6 +2,7 @@
 ---
 command:
   name: learner
+  _inactive: true
   description: manage learners
   usage: learner [options] <command>
   commands:

--- a/config/commands/log.yaml
+++ b/config/commands/log.yaml
@@ -2,6 +2,7 @@
 ---
 command:
   name: log
+  _inactive: true
   description: log reflections
   usage: log [options] [response]
   options:

--- a/config/commands/retro.yaml
+++ b/config/commands/retro.yaml
@@ -1,0 +1,13 @@
+%YAML 1.2
+---
+command:
+  name: retro
+  description: log retrospective reflections
+  usage: retro [options] [<project id>]
+  examples:
+    -
+      example: 'retro #stable-snake'
+      description: 'Begin retrospective survey for the #stable-snake project'
+    -
+      example: 'retro'
+      description: Begin retrospective survey for your current project

--- a/lib/commands/profile.js
+++ b/lib/commands/profile.js
@@ -25,11 +25,9 @@ exports.usage = usage;
 exports.commandDescriptor = commandDescriptor;
 var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, function (args, notify, options) {
   var formatMessage = options.formatMessage;
-  var formatUsage = options.formatUsage;
 
   if (args._.length > 0) {
-    notify(formatUsage(usage()));
-    return Promise.resolve();
+    return Promise.reject('Invalid arguments. Try --help for usage.');
   }
 
   notify(formatMessage('Loading your profile ...'));

--- a/lib/commands/retro.js
+++ b/lib/commands/retro.js
@@ -1,0 +1,37 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.invoke = exports.commandDescriptor = exports.usage = exports.parse = undefined;
+
+var _loadCommand2 = require('../util/loadCommand');
+
+var _loadCommand3 = _interopRequireDefault(_loadCommand2);
+
+var _composeInvoke = require('../util/composeInvoke');
+
+var _composeInvoke2 = _interopRequireDefault(_composeInvoke);
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+var _loadCommand = (0, _loadCommand3.default)('retro');
+
+var parse = _loadCommand.parse;
+var usage = _loadCommand.usage;
+var commandDescriptor = _loadCommand.commandDescriptor;
+exports.parse = parse;
+exports.usage = usage;
+exports.commandDescriptor = commandDescriptor;
+var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, function (args, notify, options) {
+  var formatMessage = options.formatMessage;
+
+  if (args._.length > 1) {
+    return Promise.reject('Invalid arguments. Try --help for usage.');
+  }
+
+  var projectName = args._.length === 1 ? args._[0].replace('#', '') : null;
+  var loadingMessage = projectName ? 'Looking for retrospective survey for #' + projectName + ' ...' : 'Looking for retrospective survey ...';
+  notify(formatMessage(loadingMessage));
+  return Promise.resolve();
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "0.13.3",
+  "version": "0.14.0",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/__tests__/profile.test.js
+++ b/src/commands/__tests__/profile.test.js
@@ -21,7 +21,7 @@ describe(testContext(__filename), function () {
     })
 
     it('notifies with the usage message when requested', notifiesWithUsageMessageForDashH)
-    it('notifies with the usage message if arguments are supplied', notifiesWithUsageHintForInvalidArgs(['ANYTHING']))
+    it('notifies with the usage hint if arguments are supplied', notifiesWithUsageHintForInvalidArgs(['ANYTHING']))
 
     it('notifies that the profile is being loaded', function () {
       return this.invoke([], this.notify)

--- a/src/commands/__tests__/retro.test.js
+++ b/src/commands/__tests__/retro.test.js
@@ -1,0 +1,44 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+
+import {
+  notifiesWithUsageMessageForDashH,
+  notifiesWithUsageHintForInvalidArgs,
+} from '../../../test/commonTests'
+
+describe(testContext(__filename), function () {
+  describe('invoke', function () {
+    before(function () {
+      this.invoke = require('../retro').invoke
+
+      this.notify = msg => {
+        this.notifications.push(msg)
+      }
+    })
+    beforeEach(function () {
+      this.notifications = []
+    })
+
+    it('notifies with the usage message when requested', notifiesWithUsageMessageForDashH)
+    it('notifies with the usage hint if too many arguments are supplied', notifiesWithUsageHintForInvalidArgs(['#first-proj', '#second-proj']))
+
+    describe('when passing a project name', function () {
+      it('notifies that the provided retrospective survey is being looked for', function () {
+        return this.invoke(['#stable-snake'], this.notify)
+          .then(() => {
+            expect(this.notifications[0]).to.match(/Looking for retrospective survey for #stable-snake .../i)
+          })
+      })
+    })
+
+    describe('without passing a project name', function () {
+      it('notifies that the retrospective survey is being looked for', function () {
+        return this.invoke(['#stable-snake'], this.notify)
+          .then(() => {
+            expect(this.notifications[0]).to.match(/Looking for retrospective survey .../i)
+          })
+      })
+    })
+  })
+})

--- a/src/commands/profile.js
+++ b/src/commands/profile.js
@@ -6,11 +6,9 @@ export const {parse, usage, commandDescriptor} = loadCommand('profile')
 export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
   const {
     formatMessage,
-    formatUsage,
   } = options
   if (args._.length > 0) {
-    notify(formatUsage(usage()))
-    return Promise.resolve()
+    return Promise.reject('Invalid arguments. Try --help for usage.')
   }
 
   notify(formatMessage('Loading your profile ...'))

--- a/src/commands/retro.js
+++ b/src/commands/retro.js
@@ -1,0 +1,20 @@
+import loadCommand from '../util/loadCommand'
+import composeInvoke from '../util/composeInvoke'
+
+export const {parse, usage, commandDescriptor} = loadCommand('retro')
+
+export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
+  const {
+    formatMessage,
+  } = options
+  if (args._.length > 1) {
+    return Promise.reject('Invalid arguments. Try --help for usage.')
+  }
+
+  const projectName = args._.length === 1 ? args._[0].replace('#', '') : null
+  const loadingMessage = projectName ?
+  `Looking for retrospective survey for #${projectName} ...` :
+  'Looking for retrospective survey ...'
+  notify(formatMessage(loadingMessage))
+  return Promise.resolve()
+})


### PR DESCRIPTION
Fixes #57 
Fixes #58 

## Primary Changes

- set `log` command to `_inactive` -- we will remove it later once we're sure we're done with it
- add `retro` command

## Also

- upgrade to latest subcli which removes an annoying `FATAL` prefix for invalid subcommands
- for consistency with other commands, provide a usage hint rather than full usage message on `profile` command for bad arguments
- be explicit in the configuration files about inactive commands