### PR TITLE
support moderators: stop depending on `lgPlayer`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,10 +1,13 @@
 # History
 
-#### 0.13.2
+#### 0.13.4
+- stop expecting `lgPlayer` -- use `lgUser` and `lgUser.roles`
+
+#### 0.13.3
 - bump subcli to 0.2.3
 
 #### 0.13.2
-- fixup /vote usage
+- fixup `/vote` usage
 
 #### 0.13.0
 - Added support for specifying project name in `/log` commands

--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ It's worth noting that the attributes are an extension of [cliclopts][cliclopts]
         lgUser: {
           // ... LG user attributes
         },
-        lgPlayer: {
-          // ... LG player attributes
-        }
       }
 
       vote.invoke(['44', '45'], console.log, options)
@@ -74,15 +71,6 @@ The command runner expects a `~/.lgrc` file to be present with attributes that w
     "roles" : [
        "player"
     ]
-  },
-  "lgPlayer" : {
-    "id" : "00000000-1111-2222-3333-444444444444",
-    "chapter" : {
-       "name" : "Chapter Name",
-       "channelName" : "chapter-name",
-       "timezone" : "America/Los_Angeles",
-       "goalRepositoryURL" : "https://github.com/GuildCraftsTesting/web-development-js-testing"
-    }
   }
 }
 ```

--- a/lib/commands/cycle.js
+++ b/lib/commands/cycle.js
@@ -25,6 +25,8 @@ var _composeInvoke = require('../util/composeInvoke');
 
 var _composeInvoke2 = _interopRequireDefault(_composeInvoke);
 
+var _userValidation = require('../util/userValidation');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var _loadCommand = (0, _loadCommand3.default)('cycle');
@@ -62,7 +64,7 @@ function handleCycleInitCommand(notify, options) {
   var formatMessage = options.formatMessage;
   var formatError = options.formatError;
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('moderator') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsModerator)(lgUser)) {
     return Promise.reject('You are not a moderator.');
   }
 
@@ -80,7 +82,7 @@ function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {
   var formatMessage = options.formatMessage;
   var formatError = options.formatError;
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('moderator') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsModerator)(lgUser)) {
     return Promise.reject('You are not a moderator.');
   }
   notify(formatMessage(statusMsg));

--- a/lib/commands/log/index.js
+++ b/lib/commands/log/index.js
@@ -13,6 +13,8 @@ var _composeInvoke = require('../../util/composeInvoke');
 
 var _composeInvoke2 = _interopRequireDefault(_composeInvoke);
 
+var _userValidation = require('../../util/userValidation');
+
 var _LogRetroCommand = require('./LogRetroCommand');
 
 var _LogRetroCommand2 = _interopRequireDefault(_LogRetroCommand);
@@ -33,7 +35,7 @@ var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, functio
   var formatError = options.formatError;
   var formatMessage = options.formatMessage;
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsPlayer)(lgUser)) {
     return Promise.reject('You are not a player in the game.');
   }
   if (args.retro && !Array.isArray(args.question)) {

--- a/lib/commands/log/index.js
+++ b/lib/commands/log/index.js
@@ -29,11 +29,11 @@ exports.usage = usage;
 exports.commandDescriptor = commandDescriptor;
 var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, function (args, notify, options) {
   var lgJWT = options.lgJWT;
-  var lgPlayer = options.lgPlayer;
+  var lgUser = options.lgUser;
   var formatError = options.formatError;
   var formatMessage = options.formatMessage;
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.');
   }
   if (args.retro && !Array.isArray(args.question)) {

--- a/lib/commands/project/setArtifact.js
+++ b/lib/commands/project/setArtifact.js
@@ -20,6 +20,8 @@ var _graphQLFetcher = require('../../util/graphQLFetcher');
 
 var _graphQLFetcher2 = _interopRequireDefault(_graphQLFetcher);
 
+var _userValidation = require('../../util/userValidation');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 function invokeSetProjectArtifactURLAPI(lgJWT, projectName, url) {
@@ -39,7 +41,7 @@ function setProjectArtifactURL(args, notify, options) {
   var formatError = options.formatError;
 
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsPlayer)(lgUser)) {
     return Promise.reject('You are not a player in the game.');
   }
   if (args._.length !== 2) {

--- a/lib/commands/project/setArtifact.js
+++ b/lib/commands/project/setArtifact.js
@@ -34,16 +34,16 @@ function invokeSetProjectArtifactURLAPI(lgJWT, projectName, url) {
 
 function setProjectArtifactURL(args, notify, options) {
   var lgJWT = options.lgJWT;
-  var lgPlayer = options.lgPlayer;
+  var lgUser = options.lgUser;
   var formatMessage = options.formatMessage;
   var formatError = options.formatError;
 
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.');
   }
   if (args._.length !== 2) {
-    return Promise.reject('Invalid command - wrong number of arguments (' + args._.length + ' for 2)');
+    return Promise.reject('Invalid command - wrong number of arguments (' + args._.length + ' for 2). Try --help for usage.');
   }
 
   var _args$_ = _slicedToArray(args._, 2);

--- a/lib/commands/review.js
+++ b/lib/commands/review.js
@@ -39,7 +39,7 @@ exports.usage = usage;
 exports.commandDescriptor = commandDescriptor;
 var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, function (args, notify, options) {
   var lgJWT = options.lgJWT;
-  var lgPlayer = options.lgPlayer;
+  var lgUser = options.lgUser;
   var formatError = options.formatError;
   var formatMessage = options.formatMessage;
 
@@ -52,20 +52,20 @@ var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, functio
     }
   };
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.');
   }
   if (isResponseCommand(args)) {
-    return handleProjectReview(lgJWT, args, notifyCallbacks).catch(function (error) {
-      _errorReporter2.default.captureException(error);
-      notify(formatError(error.message || error));
+    return handleProjectReview(lgJWT, args, notifyCallbacks).catch(function (err) {
+      _errorReporter2.default.captureException(err);
+      notify(formatError(err.message || err));
     });
   }
 
   if (isStatusCommand(args)) {
-    return handleProjectReviewStatus(lgJWT, args, notifyCallbacks).catch(function (error) {
-      _errorReporter2.default.captureException(error);
-      notify(formatError(error.message || error));
+    return handleProjectReviewStatus(lgJWT, args, notifyCallbacks).catch(function (err) {
+      _errorReporter2.default.captureException(err);
+      notify(formatError(err.message || err));
     });
   }
 

--- a/lib/commands/review.js
+++ b/lib/commands/review.js
@@ -25,6 +25,8 @@ var _graphQLFetcher = require('../util/graphQLFetcher');
 
 var _graphQLFetcher2 = _interopRequireDefault(_graphQLFetcher);
 
+var _userValidation = require('../util/userValidation');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var questionNames = ['completeness', 'quality'];
@@ -52,7 +54,7 @@ var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, functio
     }
   };
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsPlayer)(lgUser)) {
     return Promise.reject('You are not a player in the game.');
   }
   if (isResponseCommand(args)) {

--- a/lib/commands/vote.js
+++ b/lib/commands/vote.js
@@ -25,6 +25,8 @@ var _composeInvoke = require('../util/composeInvoke');
 
 var _composeInvoke2 = _interopRequireDefault(_composeInvoke);
 
+var _userValidation = require('../util/userValidation');
+
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 var _loadCommand = (0, _loadCommand3.default)('vote');
@@ -53,7 +55,7 @@ function voteForGoals(goalDescriptors, notify, options) {
   var formatMessage = options.formatMessage;
   var formatError = options.formatError;
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0 && lgUser.roles.indexOf('moderator') < 0) {
+  if (!lgJWT || !(0, _userValidation.userIsPlayer)(lgUser) && !(0, _userValidation.userIsModerator)(lgUser)) {
     return Promise.reject('You are not a player or a moderator in the game.');
   }
   if (goalDescriptors.length === 1) {

--- a/lib/commands/vote.js
+++ b/lib/commands/vote.js
@@ -49,12 +49,12 @@ function invokeVoteAPI(lgJWT, goalDescriptors) {
 
 function voteForGoals(goalDescriptors, notify, options) {
   var lgJWT = options.lgJWT;
-  var lgPlayer = options.lgPlayer;
+  var lgUser = options.lgUser;
   var formatMessage = options.formatMessage;
   var formatError = options.formatError;
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
-    return Promise.reject('You are not a player in the game.');
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0 && lgUser.roles.indexOf('moderator') < 0) {
+    return Promise.reject('You are not a player or a moderator in the game.');
   }
   if (goalDescriptors.length === 1) {
     return Promise.reject('You must vote for exactly 2 goals.');
@@ -64,9 +64,9 @@ function voteForGoals(goalDescriptors, notify, options) {
   }
 
   notify(formatMessage('Validating the goals you voted on: ' + goalDescriptors.join(', ')));
-  return invokeVoteAPI(lgJWT, goalDescriptors).catch(function (error) {
-    _errorReporter2.default.captureException(error);
-    notify(formatError(error.message || error));
+  return invokeVoteAPI(lgJWT, goalDescriptors).catch(function (err) {
+    _errorReporter2.default.captureException(err);
+    notify(formatError(err.message || err));
   });
 }
 

--- a/lib/util/userValidation.js
+++ b/lib/util/userValidation.js
@@ -1,0 +1,33 @@
+'use strict';
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.userHasRoles = userHasRoles;
+exports.userIsPlayer = userIsPlayer;
+exports.userIsModerator = userIsModerator;
+var USER_ROLES = exports.USER_ROLES = {
+  PLAYER: 'player',
+  MODERATOR: 'moderator'
+};
+
+function userHasRoles(user, roles) {
+  if (!Array.isArray(roles)) {
+    throw new Error('roles must be an array');
+  }
+  if (!user || !user.roles || !Array.isArray(user.roles)) {
+    return false;
+  }
+
+  return roles.every(function (role) {
+    return user.roles.indexOf(role) >= 0;
+  });
+}
+
+function userIsPlayer(user) {
+  return userHasRoles(user, [USER_ROLES.PLAYER]);
+}
+
+function userIsModerator(user) {
+  return userHasRoles(user, [USER_ROLES.MODERATOR]);
+}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "0.13.3",
+  "version": "0.13.4",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/__tests__/review.test.js
+++ b/src/commands/__tests__/review.test.js
@@ -23,7 +23,7 @@ describe(testContext(__filename), function () {
       this.formatError = msg => `__FMT: ${msg}`
       this.argv = ['#some-project', '--completeness', '89', '--quality', '93']
       this.lgJWT = 'not.a.real.token'
-      this.lgPlayer = {id: 'not.a.real.id'}
+      this.lgUser = {id: 'not.a.real.id', roles: ['player']}
     })
 
     beforeEach(function () {
@@ -62,8 +62,8 @@ describe(testContext(__filename), function () {
             ]
           }}})
 
-        const {lgJWT, lgPlayer} = this
-        return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+        const {lgJWT, lgUser} = this
+        return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).to.match(/completeness:\s+`8`/i)
             expect(this.notifications[0]).to.match(/quality:\s+N\/A/i)
@@ -82,8 +82,8 @@ describe(testContext(__filename), function () {
             ]
           }}})
 
-        const {lgJWT, lgPlayer} = this
-        return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+        const {lgJWT, lgUser} = this
+        return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).to.match(/artifact URL .* has not been set/i)
           })
@@ -101,8 +101,8 @@ describe(testContext(__filename), function () {
             ]
           }}})
 
-        const {lgJWT, lgPlayer} = this
-        return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+        const {lgJWT, lgUser} = this
+        return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).to.match(/completeness:\s+`8`/i)
             expect(this.notifications[0]).to.match(/quality:\s+`9`/i)
@@ -119,8 +119,8 @@ describe(testContext(__filename), function () {
             responses: [],
           }}})
 
-        const {lgJWT, lgPlayer} = this
-        return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+        const {lgJWT, lgUser} = this
+        return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).not.to.match(/completeness:/i)
             expect(this.notifications[0]).not.to.match(/quality:/i)
@@ -147,8 +147,8 @@ describe(testContext(__filename), function () {
           ]
         }}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/completeness and quality scores captured/i)
         })
@@ -172,8 +172,8 @@ describe(testContext(__filename), function () {
             ]
           }}})
 
-        const {lgJWT, lgPlayer} = this
-        return this.invoke(['#some-project', `--${scoreName}`, '89'], this.notify, {lgJWT, lgPlayer})
+        const {lgJWT, lgUser} = this
+        return this.invoke(['#some-project', `--${scoreName}`, '89'], this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).to.match(new RegExp(`${scoreName} score captured`, 'i'))
           })

--- a/src/commands/__tests__/vote.test.js
+++ b/src/commands/__tests__/vote.test.js
@@ -20,7 +20,7 @@ describe(testContext(__filename), function () {
         this.notifications.push(msg)
       }
       this.lgJWT = 'not.a.real.token'
-      this.lgPlayer = {id: 'not.a.real.id'}
+      this.lgUser = {id: 'not.a.real.id', roles: ['player']}
     })
     beforeEach(function () {
       this.notifications = []
@@ -35,8 +35,8 @@ describe(testContext(__filename), function () {
     it('notifies of GraphQL invocation errors', notifiesWithErrorForGraphQLErrors(['1', '2']))
 
     it('notifies with an error message when too few goal descriptors are provided', function () {
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['1'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/exactly 2/)
         })
@@ -47,8 +47,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1', '2', '3'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['1', '2', '3'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/disqualified/)
         })
@@ -59,8 +59,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['1', '2'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/Validating/)
         })
@@ -71,8 +71,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['1', '2'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/Validating/)
         })
@@ -83,8 +83,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {id: '00000000-1111-2222-3333-444444444444'}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['1', '2'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['1', '2'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications.length).to.equal(1)
           done()

--- a/src/commands/cycle.js
+++ b/src/commands/cycle.js
@@ -3,6 +3,7 @@ import errorReporter from '../util/errorReporter'
 import graphQLFetcher from '../util/graphQLFetcher'
 import getServiceBaseURL, {GAME} from '../util/getServiceBaseURL'
 import composeInvoke from '../util/composeInvoke'
+import {userIsModerator} from '../util/userValidation'
 
 export const {parse, usage, commandDescriptor} = loadCommand('cycle')
 
@@ -30,7 +31,7 @@ function handleCycleInitCommand(notify, options) {
     formatMessage,
     formatError
   } = options
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('moderator') < 0) {
+  if (!lgJWT || !userIsModerator(lgUser)) {
     return Promise.reject('You are not a moderator.')
   }
 
@@ -49,7 +50,7 @@ function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {
     formatMessage,
     formatError
   } = options
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('moderator') < 0) {
+  if (!lgJWT || !userIsModerator(lgUser)) {
     return Promise.reject('You are not a moderator.')
   }
   notify(formatMessage(statusMsg))

--- a/src/commands/log/__tests__/index.test.js
+++ b/src/commands/log/__tests__/index.test.js
@@ -23,7 +23,7 @@ describe(testContext(__filename), function () {
       this.formatError = msg => `__FMT: ${msg}`
       this.argv = ['-rq', '1', 'some1:25', 'some2:25', 'some3:25', 'some4:25']
       this.lgJWT = 'not.a.real.token'
-      this.lgPlayer = {id: 'not.a.real.id'}
+      this.lgUser = {id: 'not.a.real.id', roles: ['player']}
     })
 
     beforeEach(function () {
@@ -83,8 +83,8 @@ describe(testContext(__filename), function () {
         })
 
         it('prints all the questions without question instructions', function () {
-          const {lgJWT, lgPlayer} = this
-          return this.invoke(['-r'], this.notify, {lgJWT, lgPlayer}).then(() => {
+          const {lgJWT, lgUser} = this
+          return this.invoke(['-r'], this.notify, {lgJWT, lgUser}).then(() => {
             expect(this.notifications[0]).to.match(/this is the question body/i)
             expect(this.notifications[0]).to.match(/this is the second question body/i)
             expect(this.notifications[0]).to.not.match(/these are the instructions/i)
@@ -92,16 +92,16 @@ describe(testContext(__filename), function () {
         })
 
         it('prints survey instructions', function () {
-          const {lgJWT, lgPlayer} = this
-          return this.invoke(['-r'], this.notify, {lgJWT, lgPlayer}).then(() => {
+          const {lgJWT, lgUser} = this
+          return this.invoke(['-r'], this.notify, {lgJWT, lgUser}).then(() => {
             expect(this.notifications[0]).to.match(/To log a reflection,/i)
             expect(this.notifications[0]).to.match(/Then follow the instructions specified in the question to answer./i)
           })
         })
 
         it('prints status information', function () {
-          const {lgJWT, lgPlayer} = this
-          return this.invoke(['-r'], this.notify, {lgJWT, lgPlayer}).then(() => {
+          const {lgJWT, lgUser} = this
+          return this.invoke(['-r'], this.notify, {lgJWT, lgUser}).then(() => {
             expect(this.notifications[0]).to.match(/You have logged 1\/2/i)
           })
         })
@@ -146,8 +146,8 @@ describe(testContext(__filename), function () {
         })
 
         it('prints a "completed" message', function () {
-          const {lgJWT, lgPlayer} = this
-          return this.invoke(['-r'], this.notify, {lgJWT, lgPlayer}).then(() => {
+          const {lgJWT, lgUser} = this
+          return this.invoke(['-r'], this.notify, {lgJWT, lgUser}).then(() => {
             expect(this.notifications[0]).to.match(/You've completed 100%/i)
           })
         })
@@ -173,8 +173,8 @@ describe(testContext(__filename), function () {
           }
         }})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['-rq', '1'], this.notify, {lgJWT, lgPlayer}).then(() => {
+      const {lgJWT, lgUser} = this
+      return this.invoke(['-rq', '1'], this.notify, {lgJWT, lgUser}).then(() => {
         expect(this.notifications[0]).to.match(/this is the question body/i)
         expect(this.notifications[0]).to.match(/these are the instructions/i)
       })
@@ -185,8 +185,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {createdIds: ['00000000-1111-2222-3333-444444444444']}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/reflection\s*logged/i)
         })
@@ -197,8 +197,8 @@ describe(testContext(__filename), function () {
         .post('/graphql')
         .reply(200, {data: {createdIds: ['00000000-1111-2222-3333-444444444444']}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(this.argv, this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(this.argv, this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications.length).to.equal(1)
           done()

--- a/src/commands/log/index.js
+++ b/src/commands/log/index.js
@@ -6,11 +6,11 @@ export const {parse, usage, commandDescriptor} = loadCommand('log')
 export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
   const {
     lgJWT,
-    lgPlayer,
+    lgUser,
     formatError,
     formatMessage,
   } = options
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.')
   }
   if (args.retro && !Array.isArray(args.question)) {

--- a/src/commands/log/index.js
+++ b/src/commands/log/index.js
@@ -1,5 +1,6 @@
 import loadCommand from '../../util/loadCommand'
 import composeInvoke from '../../util/composeInvoke'
+import {userIsPlayer} from '../../util/userValidation'
 import LogRetroCommand from './LogRetroCommand'
 
 export const {parse, usage, commandDescriptor} = loadCommand('log')
@@ -10,7 +11,7 @@ export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
     formatError,
     formatMessage,
   } = options
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !userIsPlayer(lgUser)) {
     return Promise.reject('You are not a player in the game.')
   }
   if (args.retro && !Array.isArray(args.question)) {

--- a/src/commands/project/__tests__/index.test.js
+++ b/src/commands/project/__tests__/index.test.js
@@ -12,15 +12,15 @@ describe(testContext(__filename), function () {
       }
       this.formatError = msg => `__FMT: ${msg}`
       this.lgJWT = 'not.a.real.token'
-      this.lgPlayer = {id: 'not.a.real.id'}
+      this.lgUser = {id: 'not.a.real.id', roles: ['player']}
     })
     beforeEach(function () {
       this.notifications = []
     })
 
     it('notifies with the usage message when requested', function () {
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['-h'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['-h'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/Usage:/)
         })

--- a/src/commands/project/__tests__/setArtifact.test.js
+++ b/src/commands/project/__tests__/setArtifact.test.js
@@ -4,6 +4,14 @@
 
 import nock from 'nock'
 
+import {
+  notifiesWithUsageMessageForDashH,
+  notifiesWithUsageHintForInvalidArgs,
+  notifiesWithErrorIfNotAPlayer,
+  notifiesWithErrorForAPIErrors,
+  notifiesWithErrorForGraphQLErrors,
+} from '../../../../test/commonTests'
+
 describe(testContext(__filename), function () {
   describe('invoke', function () {
     before(function () {
@@ -15,7 +23,7 @@ describe(testContext(__filename), function () {
       }
       this.formatError = msg => `__FMT: ${msg}`
       this.lgJWT = 'not.a.real.token'
-      this.lgPlayer = {id: 'not.a.real.id'}
+      this.lgUser = {id: 'not.a.real.id', roles: ['player']}
     })
     beforeEach(function () {
       this.notifications = []
@@ -25,81 +33,24 @@ describe(testContext(__filename), function () {
       nock.cleanAll()
     })
 
-    it('notifies with the usage message when requested', function () {
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['-h'], this.notify, {lgJWT, lgPlayer})
-        .then(() => {
-          expect(this.notifications[0]).to.match(/Usage:/)
-        })
-    })
-
-    it('notifies with an error message when too few positional arguments are provided', function () {
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['#bad-lemurs-12'], this.notify, {lgJWT, lgPlayer})
-        .then(() => {
-          expect(this.notifications[0]).to.match(/wrong number of arguments/)
-        })
-    })
-
-    it('notifies with a warning if too many positional arguments are provided', function () {
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['#bad-lemurs-12', '#good-bears-2', 'http://example.com'], this.notify, {lgJWT, lgPlayer})
-        .then(() => {
-          expect(this.notifications[0]).to.match(/wrong number of arguments/)
-        })
-    })
-
+    it('notifies with the usage message when requested', notifiesWithUsageMessageForDashH)
+    it('notifies with an error message when too few positional arguments are provided', notifiesWithUsageHintForInvalidArgs(['#bad-lemurs-12']))
+    it('notifies with a warning if too many positional arguments are provided', notifiesWithUsageHintForInvalidArgs(['#bad-lemurs-12', '#good-bears-2', 'http://example.com']))
     it('notifies with an error message when invoked by a non-player', function () {
-      const {lgJWT} = this
-      return Promise.all([
-        this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgPlayer: null})
-          .then(() => {
-            expect(this.notifications[0]).to.match(/not a player/)
-          }),
-        this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgPlayer: {object: 'without id attribute'}})
-          .then(() => {
-            expect(this.notifications[1]).to.match(/not a player/)
-          })
-      ])
+      return notifiesWithErrorIfNotAPlayer(['#bad-lemurs-12', 'http://example.com/']).bind(this)()
     })
+    it('notifies of API invocation errors', notifiesWithErrorForAPIErrors(['#bad-lemurs-12', 'http://example.com/']))
+    it('notifies of GraphQL invocation errors', notifiesWithErrorForGraphQLErrors(['#bad-lemurs-12', 'http://example.com/']))
 
     it('notifies with a thank you message when the API invocation succeeds', function (done) {
       nock('http://game.learnersguild.test')
         .post('/graphql')
         .reply(200, {data: {setProjectArtifactURL: {id: '00000000-1111-2222-3333-444444444444'}}})
 
-      const {lgJWT, lgPlayer} = this
-      return this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgPlayer})
+      const {lgJWT, lgUser} = this
+      return this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgUser})
         .then(() => {
           expect(this.notifications[0]).to.match(/Thanks! The artifact for .+ is now set to .+/)
-          done()
-        })
-        .catch(err => done(err))
-    })
-
-    it('notifies of API invocation errors', function (done) {
-      nock('http://game.learnersguild.test')
-        .post('/graphql')
-        .reply(500, 'Internal Server Error')
-
-      const {lgJWT, lgPlayer, formatError} = this
-      return this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgPlayer, formatError})
-        .then(() => {
-          expect(this.notifications[0]).to.equal('__FMT: Internal Server Error')
-          done()
-        })
-        .catch(err => done(err))
-    })
-
-    it('notifies of GraphQL invocation errors', function (done) {
-      nock('http://game.learnersguild.test')
-        .post('/graphql')
-        .reply(200, {errors: [{message: 'GraphQL Error'}]})
-
-      const {lgJWT, lgPlayer, formatError} = this
-      this.invoke(['#bad-lemurs-12', 'http://example.com/'], this.notify, {lgJWT, lgPlayer, formatError})
-        .then(() => {
-          expect(this.notifications[0]).to.equal('__FMT: GraphQL Error')
           done()
         })
         .catch(err => done(err))

--- a/src/commands/project/setArtifact.js
+++ b/src/commands/project/setArtifact.js
@@ -1,6 +1,7 @@
 import getServiceBaseURL, {GAME} from '../../util/getServiceBaseURL'
 import errorReporter from '../../util/errorReporter'
 import graphQLFetcher from '../../util/graphQLFetcher'
+import {userIsPlayer} from '../../util/userValidation'
 
 function invokeSetProjectArtifactURLAPI(lgJWT, projectName, url) {
   const mutation = {
@@ -25,7 +26,7 @@ export function setProjectArtifactURL(args, notify, options) {
     formatError
   } = options
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !userIsPlayer(lgUser)) {
     return Promise.reject('You are not a player in the game.')
   }
   if (args._.length !== 2) {

--- a/src/commands/project/setArtifact.js
+++ b/src/commands/project/setArtifact.js
@@ -20,16 +20,16 @@ mutation($projectName: String!, $url: URL!) {
 export function setProjectArtifactURL(args, notify, options) {
   const {
     lgJWT,
-    lgPlayer,
+    lgUser,
     formatMessage,
     formatError
   } = options
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.')
   }
   if (args._.length !== 2) {
-    return Promise.reject(`Invalid command - wrong number of arguments (${args._.length} for 2)`)
+    return Promise.reject(`Invalid command - wrong number of arguments (${args._.length} for 2). Try --help for usage.`)
   }
 
   const [projectNameOrChannel, url] = args._

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -3,6 +3,7 @@ import composeInvoke from '../util/composeInvoke'
 import getServiceBaseURL, {GAME} from '../util/getServiceBaseURL'
 import errorReporter from '../util/errorReporter'
 import graphQLFetcher from '../util/graphQLFetcher'
+import {userIsPlayer} from '../util/userValidation'
 
 const questionNames = ['completeness', 'quality']
 
@@ -19,7 +20,7 @@ export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
     error: err => notify(formatError(err)),
   }
 
-  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
+  if (!lgJWT || !userIsPlayer(lgUser)) {
     return Promise.reject('You are not a player in the game.')
   }
   if (isResponseCommand(args)) {

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -10,7 +10,7 @@ export const {parse, usage, commandDescriptor} = loadCommand('review')
 export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
   const {
     lgJWT,
-    lgPlayer,
+    lgUser,
     formatError,
     formatMessage,
   } = options
@@ -19,22 +19,22 @@ export const invoke = composeInvoke(parse, usage, (args, notify, options) => {
     error: err => notify(formatError(err)),
   }
 
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
+  if (!lgJWT || !lgUser || lgUser.roles.indexOf('player') < 0) {
     return Promise.reject('You are not a player in the game.')
   }
   if (isResponseCommand(args)) {
     return handleProjectReview(lgJWT, args, notifyCallbacks)
-      .catch(error => {
-        errorReporter.captureException(error)
-        notify(formatError(error.message || error))
+      .catch(err => {
+        errorReporter.captureException(err)
+        notify(formatError(err.message || err))
       })
   }
 
   if (isStatusCommand(args)) {
     return handleProjectReviewStatus(lgJWT, args, notifyCallbacks)
-      .catch(error => {
-        errorReporter.captureException(error)
-        notify(formatError(error.message || error))
+      .catch(err => {
+        errorReporter.captureException(err)
+        notify(formatError(err.message || err))
       })
   }
 
@@ -149,4 +149,3 @@ function projectReviewStatusMessage(projectName, status) {
 
   return statusMessage
 }
-

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -24,12 +24,12 @@ mutation($goalDescriptors: [String]!) {
 function voteForGoals(goalDescriptors, notify, options) {
   const {
     lgJWT,
-    lgPlayer,
+    lgUser,
     formatMessage,
     formatError
   } = options
-  if (!lgJWT || !lgPlayer || !lgPlayer.id) {
-    return Promise.reject('You are not a player in the game.')
+  if (!lgJWT || !lgUser || (lgUser.roles.indexOf('player') < 0 && lgUser.roles.indexOf('moderator') < 0)) {
+    return Promise.reject('You are not a player or a moderator in the game.')
   }
   if (goalDescriptors.length === 1) {
     return Promise.reject('You must vote for exactly 2 goals.')
@@ -40,9 +40,9 @@ function voteForGoals(goalDescriptors, notify, options) {
 
   notify(formatMessage(`Validating the goals you voted on: ${goalDescriptors.join(', ')}`))
   return invokeVoteAPI(lgJWT, goalDescriptors)
-    .catch(error => {
-      errorReporter.captureException(error)
-      notify(formatError(error.message || error))
+    .catch(err => {
+      errorReporter.captureException(err)
+      notify(formatError(err.message || err))
     })
 }
 

--- a/src/commands/vote.js
+++ b/src/commands/vote.js
@@ -3,6 +3,7 @@ import errorReporter from '../util/errorReporter'
 import graphQLFetcher from '../util/graphQLFetcher'
 import getServiceBaseURL, {GAME} from '../util/getServiceBaseURL'
 import composeInvoke from '../util/composeInvoke'
+import {userIsPlayer, userIsModerator} from '../util/userValidation'
 
 export const {parse, usage, commandDescriptor} = loadCommand('vote')
 
@@ -28,7 +29,7 @@ function voteForGoals(goalDescriptors, notify, options) {
     formatMessage,
     formatError
   } = options
-  if (!lgJWT || !lgUser || (lgUser.roles.indexOf('player') < 0 && lgUser.roles.indexOf('moderator') < 0)) {
+  if (!lgJWT || (!userIsPlayer(lgUser) && !userIsModerator(lgUser))) {
     return Promise.reject('You are not a player or a moderator in the game.')
   }
   if (goalDescriptors.length === 1) {

--- a/src/util/__tests__/userValidation.test.js
+++ b/src/util/__tests__/userValidation.test.js
@@ -1,0 +1,69 @@
+/* eslint-env mocha */
+/* global expect, testContext */
+/* eslint-disable prefer-arrow-callback, no-unused-expressions */
+
+import {
+  userHasRoles,
+  userIsPlayer,
+  userIsModerator,
+} from '../userValidation'
+
+describe(testContext(__filename), function () {
+  describe('userHasRoles', function () {
+    it('throws an error if the passed-in roles to check is not an array', function () {
+      expect(() => userHasRoles({}, '')).to.throw(/roles must be an array/)
+      expect(() => userHasRoles(null, {})).to.throw(/roles must be an array/)
+    })
+
+    it('returns false if the user is null', function () {
+      expect(userHasRoles(null, ['player'])).to.equal(false)
+    })
+    it('returns false if the user has no `roles` property', function () {
+      const user = {id: 'not.a.real.id', handle: 'abc123'}
+      expect(userHasRoles(user, ['player'])).to.equal(false)
+    })
+
+    it('returns false if the `roles` property is not an array', function () {
+      const user = {id: 'not.a.real.id', handle: 'abc123', roles: 'player'}
+      expect(userHasRoles(user, ['player'])).to.equal(false)
+    })
+
+    it('returns false if the user does not have the given roles', function () {
+      const user = {id: 'not.a.real.id', handle: 'abc123', roles: ['backoffice']}
+      expect(userHasRoles(user, ['player'])).to.equal(false)
+    })
+
+    it('returns true if the user has the given roles', function () {
+      const user = {id: 'not.a.real.id', handle: 'abc123', roles: ['backoffice', 'player', 'moderator']}
+      expect(userHasRoles(user, ['backoffice', 'moderator'])).to.equal(true)
+    })
+  })
+
+  describe('userIsPlayer', function () {
+    it('returns false if the user does not have the `player` role', function () {
+      expect(userIsPlayer(null)).to.equal(false)
+      expect(userIsPlayer({})).to.equal(false)
+      expect(userIsPlayer({id: 'not.a.real.id', handle: 'abc123'})).to.equal(false)
+      expect(userIsPlayer({id: 'not.a.real.id', handle: 'abc123', roles: 'player'})).to.equal(false)
+      expect(userIsPlayer({id: 'not.a.real.id', handle: 'abc123', roles: ['moderator']})).to.equal(false)
+    })
+
+    it('returns true if the user has the `player` role', function () {
+      expect(userIsPlayer({id: 'not.a.real.id', handle: 'abc123', roles: ['player']})).to.equal(true)
+    })
+  })
+
+  describe('userIsModerator', function () {
+    it('returns false if the user does not have the `moderator` role', function () {
+      expect(userIsModerator(null)).to.equal(false)
+      expect(userIsModerator({})).to.equal(false)
+      expect(userIsModerator({id: 'not.a.real.id', handle: 'abc123'})).to.equal(false)
+      expect(userIsModerator({id: 'not.a.real.id', handle: 'abc123', roles: 'moderator'})).to.equal(false)
+      expect(userIsModerator({id: 'not.a.real.id', handle: 'abc123', roles: ['player']})).to.equal(false)
+    })
+
+    it('returns true if the user has the `moderator` role', function () {
+      expect(userIsModerator({id: 'not.a.real.id', handle: 'abc123', roles: ['moderator']})).to.equal(true)
+    })
+  })
+})

--- a/src/util/userValidation.js
+++ b/src/util/userValidation.js
@@ -1,0 +1,23 @@
+export const USER_ROLES = {
+  PLAYER: 'player',
+  MODERATOR: 'moderator',
+}
+
+export function userHasRoles(user, roles) {
+  if (!Array.isArray(roles)) {
+    throw new Error('roles must be an array')
+  }
+  if (!user || !user.roles || !Array.isArray(user.roles)) {
+    return false
+  }
+
+  return roles.every(role => user.roles.indexOf(role) >= 0)
+}
+
+export function userIsPlayer(user) {
+  return userHasRoles(user, [USER_ROLES.PLAYER])
+}
+
+export function userIsModerator(user) {
+  return userHasRoles(user, [USER_ROLES.MODERATOR])
+}


### PR DESCRIPTION
We need to make sure that moderators can issue any moderator-relevant command (like `vote` sliding out the voting panel).

Previously, some of the commands depended on information from the player record (e.g., `chapterId`, `goalRepositoryURL`). However, now all of the checking for that is (rightfully) done on the game server and this dependency is no longer in place.

The only thing remaining-in-use by game-cli from the `lgPlayer` attribute is the id (to ensure that the user is a player, which we can just as easily do with lgUser.roles). This commit removes any dependency that game-cli has on an `lgPlayer` being passed-in.