### PR TITLE
Fix bug with partial reviews

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+#### 1.1.4
+- Fix bug when submitting a partial project review
+
 #### 1.1.0
 - add `/project list` subcommand
 

--- a/lib/commands/review.js
+++ b/lib/commands/review.js
@@ -82,7 +82,9 @@ function handleProjectReview(lgJWT, args, _ref) {
   var msg = _ref.msg;
 
   var projectName = args._[0].replace('#', '');
-  var responses = questionNames.map(function (questionName) {
+  var responses = questionNames.filter(function (questionName) {
+    return questionName in args;
+  }).map(function (questionName) {
     return {
       questionName: questionName,
       responseParams: [args[questionName]]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/review.js
+++ b/src/commands/review.js
@@ -48,10 +48,12 @@ function isStatusCommand(args) {
 
 function handleProjectReview(lgJWT, args, {msg}) {
   const projectName = args._[0].replace('#', '')
-  const responses = questionNames.map(questionName => ({
-    questionName,
-    responseParams: [args[questionName]]
-  }))
+  const responses = questionNames
+    .filter(questionName => questionName in args)
+    .map(questionName => ({
+      questionName,
+      responseParams: [args[questionName]]
+    }))
 
   return invokeSaveProjectReviewCLISurveyResponsesAPI(lgJWT, projectName, responses)
     .then(() => invokeGetProjectReviewSurveyStatusAPI(lgJWT, projectName))


### PR DESCRIPTION
We were sending 2 responses every time someone issued the `/review`
command, even if they were only recording a response for one question.

For example:

```
/review #happy-frog -c 99
```

Would cause game-cli to send 2 responses to the game service one for the
completness question with the responseParams `['99']`, and another for the quality
question with the responseParams `[null]`

Fixes #80