### PR TITLE
include goal info in `project list -r` output

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -33,3 +33,4 @@ ratings:
   - "**.rb"
 exclude_paths:
 - lib/
+- "__tests__/"

--- a/lib/commands/project/list.js
+++ b/lib/commands/project/list.js
@@ -25,7 +25,7 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function invokeProjectListWithReviewsAPI(lgJWT) {
   var query = {
-    query: '\nquery {\n  getProjectsAndReviewResponsesForPlayer {\n    name\n    artifactURL\n    projectReviewResponses {\n      name\n      value\n    }\n  }\n}\n    '
+    query: '\nquery {\n  getProjectsAndReviewResponsesForPlayer {\n    name\n    artifactURL\n    goal {\n      number\n      title\n      url\n    }\n    projectReviewResponses {\n      name\n      value\n    }\n  }\n}\n    '
   };
   return (0, _graphQLFetcher2.default)(lgJWT, (0, _getServiceBaseURL2.default)(_getServiceBaseURL.GAME))(query).then(function (data) {
     return data.getProjectsAndReviewResponsesForPlayer;
@@ -42,10 +42,10 @@ function invokeProjectListSummaryAPI(lgJWT) {
 }
 
 var CHK_WIDTH = 1;
-var PROJ_WIDTH = 21;
+var PROJ_WIDTH = 22;
 var CMPL_WIDTH = 3;
 var QUAL_WIDTH = 3;
-var ARTF_WIDTH = 40;
+var ARGL_WIDTH = 40;
 function formatProjectList(projects) {
   var numReviewed = projects.filter(function (proj) {
     return proj.projectReviewResponses.filter(function (resp) {
@@ -54,8 +54,8 @@ function formatProjectList(projects) {
   }).length;
   var preface = 'You have reviewed ' + numReviewed + ' / ' + projects.length + ' projects this cycle. Nice work!';
   var fmt = '%-' + CHK_WIDTH + 's  %-' + PROJ_WIDTH + 's  %-' + CMPL_WIDTH + 's  %-' + QUAL_WIDTH + 's  %s';
-  var header = (0, _sprintfJs.sprintf)(fmt, '', 'Project', 'C', 'Q', 'Artifact');
-  var underlines = (0, _sprintfJs.sprintf)(fmt, '', '-'.repeat(PROJ_WIDTH), '-'.repeat(CMPL_WIDTH), '-'.repeat(QUAL_WIDTH), '-'.repeat(ARTF_WIDTH));
+  var header = (0, _sprintfJs.sprintf)(fmt, '', 'Project', 'C', 'Q', 'Goal / Artifact');
+  var underlines = (0, _sprintfJs.sprintf)(fmt, '', '-'.repeat(PROJ_WIDTH), '-'.repeat(CMPL_WIDTH), '-'.repeat(QUAL_WIDTH), '-'.repeat(ARGL_WIDTH));
   var projectLines = projects.map(function (proj) {
     var completeness = proj.projectReviewResponses.find(function (resp) {
       return resp.name === 'completeness';
@@ -64,7 +64,8 @@ function formatProjectList(projects) {
       return resp.name === 'quality';
     }).value;
     var reviewed = completeness && quality ? '✓' : '-';
-    return (0, _sprintfJs.sprintf)(fmt, reviewed, '#' + proj.name, completeness || '', quality || '', proj.artifactURL || '');
+    var goalInfo = proj.goal.number + ': ' + proj.goal.title;
+    return [(0, _sprintfJs.sprintf)(fmt, reviewed, '#' + proj.name, completeness || '', quality || '', goalInfo), (0, _sprintfJs.sprintf)(fmt, '', '', '', '', proj.artifactURL || '')].join('\n') + (proj.artifactURL ? '\n' : '');
   });
 
   return preface + '\n\n```\n' + header + '\n' + underlines + '\n' + projectLines.join('\n') + '\n```';

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/project/__tests__/list.test.js
+++ b/src/commands/project/__tests__/list.test.js
@@ -55,6 +55,11 @@ describe(testContext(__filename), function () {
         getProjectsAndReviewResponsesForPlayer: [{
           name: 'frightened-grouse',
           artifactURL: 'http://example.com',
+          goal: {
+            number: 12,
+            title: 'Develop some 4w350m3n355',
+            url: 'http://example.com',
+          },
           projectReviewResponses: [{
             name: 'quality',
             value: '88',
@@ -65,6 +70,11 @@ describe(testContext(__filename), function () {
         }, {
           name: 'helpless-rat',
           artifactURL: null,
+          goal: {
+            number: 12,
+            title: 'Develop some 4w350m3n355',
+            url: 'http://example.com',
+          },
           projectReviewResponses: [{
             name: 'quality',
             value: null,
@@ -75,6 +85,11 @@ describe(testContext(__filename), function () {
         }, {
           name: 'magnificent-galah',
           artifactURL: null,
+          goal: {
+            number: 13,
+            title: '1337 h4x0rz ftw',
+            url: 'http://example.com',
+          },
           projectReviewResponses: [{
             name: 'quality',
             value: null,
@@ -85,6 +100,11 @@ describe(testContext(__filename), function () {
         }, {
           name: 'ordinary-wapiti',
           artifactURL: null,
+          goal: {
+            number: 14,
+            title: 'b00m g035 th3 d4y',
+            url: 'http://example.com',
+          },
           projectReviewResponses: [{
             name: 'quality',
             value: null,
@@ -116,8 +136,9 @@ describe(testContext(__filename), function () {
       const {lgJWT, lgUser} = this
       return this.invoke(['-r'], this.notify, {lgJWT, lgUser})
         .then(() => {
+          console.log(this.notifications)
           expect(this.notifications[0]).to.match(/have reviewed 1 \/ 4 projects/)
-          expect(this.notifications[0]).to.match(/Project\s+C\s+Q\s+Artifact/)
+          expect(this.notifications[0]).to.match(/Project\s+C\s+Q\s+Goal\s\/\sArtifact/)
           expect(this.notifications[0]).to.match(/example\.com/)
           expect(this.notifications[0]).to.match(/23\s+88/)
           _projectList.data.getProjectsAndReviewResponsesForPlayer.forEach(p => {

--- a/src/commands/project/list.js
+++ b/src/commands/project/list.js
@@ -12,6 +12,11 @@ query {
   getProjectsAndReviewResponsesForPlayer {
     name
     artifactURL
+    goal {
+      number
+      title
+      url
+    }
     projectReviewResponses {
       name
       value
@@ -40,23 +45,27 @@ query {
 }
 
 const CHK_WIDTH = 1
-const PROJ_WIDTH = 21
+const PROJ_WIDTH = 22
 const CMPL_WIDTH = 3
 const QUAL_WIDTH = 3
-const ARTF_WIDTH = 40
+const ARGL_WIDTH = 40
 function formatProjectList(projects) {
   const numReviewed = projects.filter(proj => (
     proj.projectReviewResponses.filter(resp => resp.value).length > 0
   )).length
   const preface = `You have reviewed ${numReviewed} / ${projects.length} projects this cycle. Nice work!`
   const fmt = `%-${CHK_WIDTH}s  %-${PROJ_WIDTH}s  %-${CMPL_WIDTH}s  %-${QUAL_WIDTH}s  %s`
-  const header = sprintf(fmt, '', 'Project', 'C', 'Q', 'Artifact')
-  const underlines = sprintf(fmt, '', '-'.repeat(PROJ_WIDTH), '-'.repeat(CMPL_WIDTH), '-'.repeat(QUAL_WIDTH), '-'.repeat(ARTF_WIDTH))
+  const header = sprintf(fmt, '', 'Project', 'C', 'Q', 'Goal / Artifact')
+  const underlines = sprintf(fmt, '', '-'.repeat(PROJ_WIDTH), '-'.repeat(CMPL_WIDTH), '-'.repeat(QUAL_WIDTH), '-'.repeat(ARGL_WIDTH))
   const projectLines = projects.map(proj => {
     const completeness = proj.projectReviewResponses.find(resp => resp.name === 'completeness').value
     const quality = proj.projectReviewResponses.find(resp => resp.name === 'quality').value
     const reviewed = completeness && quality ? '✓' : '-'
-    return sprintf(fmt, reviewed, `#${proj.name}`, completeness || '', quality || '', proj.artifactURL || '')
+    const goalInfo = `${proj.goal.number}: ${proj.goal.title}`
+    return [
+      sprintf(fmt, reviewed, `#${proj.name}`, completeness || '', quality || '', goalInfo),
+      sprintf(fmt, '', '', '', '', proj.artifactURL || ''),
+    ].join('\n') + (proj.artifactURL ? '\n' : '')
   })
 
   return `${preface}\n\n\`\`\`\n${header}\n${underlines}\n${projectLines.join('\n')}\n\`\`\``


### PR DESCRIPTION
Partially addresses [ch204](https://app.clubhouse.io/learnersguild/story/204/project-list-r-should-list-the-goal).

## Overview

Minimizes time wasted by Support Engineering answering questions about which goals are associated with which projects.

Each project line in the output of the `project list -r` command will now show the goal number and title on the first line. The second line will show the artifact URL (if it is set). A blank line will always be printed between project lines (for readability).

### Example

You have reviewed 0 / 12 projects this cycle. Nice work!

```
   Project                 C    Q    Goal / Artifact
   ----------------------  ---  ---  ----------------------------------------
-  #aberrant-hippopotamus            128: Core Data Structures

-  #ablaze-starfish                  64: To Do List App
                                     https://github.com/kousagi1012/ablaze-starfish

-  #adhesive-tanager                 118: Learn SQL and Explore Data Visualization with Chart.js

-  #chemical-lapwing                 128: Core Data Structures

-  #elated-cockatoo                  29: Reverse-engineered social media site with HTML & CSS

-  #envious-parakeet                 122: Blogetty-blog-blog: Make A Blog Site

-  #flaky-whale                      115: Coach-Que : schedule time & incorporate feedback

-  #glib-kinkajou                    126: MetroRail: Data Modeling & Database Design

-  #graceful-pie                     83: Simon Game Tutorial

-  #grandiose-serval                 64: To Do List App

-  #imaginary-shrew                  120: Implement the card game `Set`
                                     https://github.com/HJBowers/imaginary-shrew

-  #imported-elephant                83: Simon Game Tutorial
```

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

As part of this change, I also asked CodeClimate to ignore the `__tests__` folder (for good measure).

## Notes

N/A