### PR TITLE
add `--hours` option to `cycle init`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,8 @@
 # History
 
+#### 1.3.0
+- Add `--hours` option for `cycle init`.
+
 #### 1.2.0
 - Adding playbook command
 

--- a/config/commands/cycle.yaml
+++ b/config/commands/cycle.yaml
@@ -12,7 +12,7 @@ command:
       options:
         -
           name: hours
-          help: The maximum scoped billable hours for this cycle.
+          help: The default expected hours for projects in this cycle.
     -
       name: launch
       description: Tally votes and create project teams.
@@ -32,7 +32,7 @@ command:
       description: Get help on initializing a cycle.
     -
       example: cycle init --hours=32
-      description: Initialize a cycle with a maximum of 32 scoped billable hours.
+      description: Initialize a cycle that expects 32 hours of work for each project.
     -
       example: cycle reflect
       description: Start the reflection (retrospective and review) process for the current cycle.

--- a/config/commands/cycle.yaml
+++ b/config/commands/cycle.yaml
@@ -9,6 +9,10 @@ command:
       name: init
       description: Create a new Cycle
       usage: init [options]
+      options:
+        -
+          name: hours
+          help: The maximum scoped billable hours for this cycle.
     -
       name: launch
       description: Tally votes and create project teams.
@@ -26,6 +30,9 @@ command:
     -
       example: cycle init --help
       description: Get help on initializing a cycle.
+    -
+      example: cycle init --hours=32
+      description: Initialize a cycle with a maximum of 32 scoped billable hours.
     -
       example: cycle reflect
       description: Start the reflection (retrospective and review) process for the current cycle.

--- a/lib/commands/cycle.js
+++ b/lib/commands/cycle.js
@@ -49,16 +49,17 @@ function invokeUpdateCycleStateAPI(state, lgJWT) {
   });
 }
 
-function invokeCreateCycleAPI(lgJWT) {
+function invokeCreateCycleAPI(lgJWT, scopedBillableHours) {
   var mutation = {
-    query: 'mutation { createCycle { id cycleNumber } }'
+    query: 'mutation($scopedBillableHours: Int) { createCycle(scopedBillableHours: $scopedBillableHours) { id cycleNumber scopedBillableHours } }',
+    variables: { scopedBillableHours: scopedBillableHours }
   };
   return (0, _graphQLFetcher2.default)(lgJWT, (0, _getServiceBaseURL2.default)(_getServiceBaseURL.GAME))(mutation).then(function (data) {
     return data.createCycle;
   });
 }
 
-function handleCycleInitCommand(notify, options) {
+function handleCycleInitCommand(args, notify, options) {
   var lgJWT = options.lgJWT;
   var lgUser = options.lgUser;
   var formatMessage = options.formatMessage;
@@ -68,8 +69,10 @@ function handleCycleInitCommand(notify, options) {
     return Promise.reject('You are not a moderator.');
   }
 
-  return invokeCreateCycleAPI(lgJWT).then(function (cycle) {
-    return notify(formatMessage('Cycle #' + cycle.cycleNumber + ' Initializing... stand by.'));
+  var hoursInfo = args.hours ? 'with ' + args.hours + ' hours ' : '';
+
+  return invokeCreateCycleAPI(lgJWT, args.hours).then(function (cycle) {
+    return notify(formatMessage('Cycle #' + cycle.cycleNumber + ' Initializing ' + hoursInfo + '... stand by.'));
   }).catch(function (err) {
     _errorReporter2.default.captureException(err);
     notify(formatError(err.message || err));
@@ -93,10 +96,10 @@ function handleUpdateCycleStateCommand(state, statusMsg, notify, options) {
 }
 
 var invoke = exports.invoke = (0, _composeInvoke2.default)(parse, usage, function (args, notify, options) {
-  if (args._.length === 1) {
+  if (args._.length >= 1) {
     var subcommandFuncs = {
       init: function init() {
-        return handleCycleInitCommand(notify, options);
+        return handleCycleInitCommand(args.$.init, notify, options);
       },
       launch: function launch() {
         return handleUpdateCycleStateCommand('PRACTICE', '🚀  Initiating Launch... stand by.', notify, options);

--- a/lib/commands/cycle.js
+++ b/lib/commands/cycle.js
@@ -49,10 +49,10 @@ function invokeUpdateCycleStateAPI(state, lgJWT) {
   });
 }
 
-function invokeCreateCycleAPI(lgJWT, scopedBillableHours) {
+function invokeCreateCycleAPI(lgJWT, projectDefaultExpectedHours) {
   var mutation = {
-    query: 'mutation($scopedBillableHours: Int) { createCycle(scopedBillableHours: $scopedBillableHours) { id cycleNumber scopedBillableHours } }',
-    variables: { scopedBillableHours: scopedBillableHours }
+    query: 'mutation($projectDefaultExpectedHours: Int) { createCycle(projectDefaultExpectedHours: $projectDefaultExpectedHours) { id cycleNumber projectDefaultExpectedHours } }',
+    variables: { projectDefaultExpectedHours: projectDefaultExpectedHours }
   };
   return (0, _graphQLFetcher2.default)(lgJWT, (0, _getServiceBaseURL2.default)(_getServiceBaseURL.GAME))(mutation).then(function (data) {
     return data.createCycle;
@@ -69,7 +69,7 @@ function handleCycleInitCommand(args, notify, options) {
     return Promise.reject('You are not a moderator.');
   }
 
-  var hoursInfo = args.hours ? 'with ' + args.hours + ' hours ' : '';
+  var hoursInfo = args.hours ? 'with ' + args.hours + ' expected hours per project ' : '';
 
   return invokeCreateCycleAPI(lgJWT, args.hours).then(function (cycle) {
     return notify(formatMessage('Cycle #' + cycle.cycleNumber + ' Initializing ' + hoursInfo + '... stand by.'));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {

--- a/src/commands/__tests__/cycle.test.js
+++ b/src/commands/__tests__/cycle.test.js
@@ -47,15 +47,30 @@ describe(testContext(__filename), function () {
     })
 
     describe('cycle init', function () {
+      beforeEach(function () {
+        nock.cleanAll()
+      })
+
       it('notifies user on success', function () {
         nock('http://game.learnersguild.test')
           .post('/graphql')
-          .reply(200, {data: {createCycle: {cycleNumber: 3}}})
+          .reply(200, {data: {createCycle: {cycleNumber: 3, hours: 40}}})
 
         const {lgJWT, lgUser} = this
         return this.invoke(['init'], this.notify, {lgJWT, lgUser})
           .then(() => {
             expect(this.notifications[0]).to.match(/Cycle #3/i)
+          })
+      })
+      it('confirms the number of hours when passed', function () {
+        nock('http://game.learnersguild.test')
+          .post('/graphql')
+          .reply(200, {data: {createCycle: {cycleNumber: 4, hours: 32}}})
+
+        const {lgJWT, lgUser} = this
+        return this.invoke(['init', '--hours=32'], this.notify, {lgJWT, lgUser})
+          .then(() => {
+            expect(this.notifications[0]).to.match(/Cycle #4.*with 32 hours/i)
           })
       })
       it('notifies of API invocation errors', notifiesWithErrorForAPIErrors(['init']))

--- a/src/commands/__tests__/cycle.test.js
+++ b/src/commands/__tests__/cycle.test.js
@@ -70,7 +70,7 @@ describe(testContext(__filename), function () {
         const {lgJWT, lgUser} = this
         return this.invoke(['init', '--hours=32'], this.notify, {lgJWT, lgUser})
           .then(() => {
-            expect(this.notifications[0]).to.match(/Cycle #4.*with 32 hours/i)
+            expect(this.notifications[0]).to.match(/Cycle #4.*with 32 expected hours/i)
           })
       })
       it('notifies of API invocation errors', notifiesWithErrorForAPIErrors(['init']))

--- a/src/commands/cycle.js
+++ b/src/commands/cycle.js
@@ -16,10 +16,10 @@ function invokeUpdateCycleStateAPI(state, lgJWT) {
     .then(data => data.updateCycleState)
 }
 
-function invokeCreateCycleAPI(lgJWT, scopedBillableHours) {
+function invokeCreateCycleAPI(lgJWT, projectDefaultExpectedHours) {
   const mutation = {
-    query: 'mutation($scopedBillableHours: Int) { createCycle(scopedBillableHours: $scopedBillableHours) { id cycleNumber scopedBillableHours } }',
-    variables: {scopedBillableHours},
+    query: 'mutation($projectDefaultExpectedHours: Int) { createCycle(projectDefaultExpectedHours: $projectDefaultExpectedHours) { id cycleNumber projectDefaultExpectedHours } }',
+    variables: {projectDefaultExpectedHours},
   }
   return graphQLFetcher(lgJWT, getServiceBaseURL(GAME))(mutation)
     .then(data => data.createCycle)
@@ -36,7 +36,7 @@ function handleCycleInitCommand(args, notify, options) {
     return Promise.reject('You are not a moderator.')
   }
 
-  const hoursInfo = args.hours ? `with ${args.hours} hours ` : ''
+  const hoursInfo = args.hours ? `with ${args.hours} expected hours per project ` : ''
 
   return invokeCreateCycleAPI(lgJWT, args.hours)
     .then(cycle => notify(formatMessage(`Cycle #${cycle.cycleNumber} Initializing ${hoursInfo}... stand by.`)))


### PR DESCRIPTION
Partially addresses [ch101](https://app.clubhouse.io/learnersguild/story/101/players-have-timeontask-stat).

## Overview

The `cycle init` command now provides the option to pass an `--hours` argument to specify the `scopedBillableHours` for the cycle and its related projects.

## Data Model / DB Schema Changes

N/A

## Environment / Configuration Changes

N/A

## Notes

- Related: https://github.com/LearnersGuild/echo-chat/pull/83
- Related: https://github.com/LearnersGuild/game/pull/716
