### PR TITLE
ch2315 - Simplifies cycle init command

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,9 @@
 # History
 
+#### 2.1.3
+
+- In `cycle init`, change hours from an option to an argument.
+
 #### 1.3.0
 - Add `--hours` option for `cycle init`.
 

--- a/config/commands/cycle.yaml
+++ b/config/commands/cycle.yaml
@@ -8,11 +8,7 @@ command:
     -
       name: init
       description: Create a new Cycle
-      usage: init [options]
-      options:
-        -
-          name: hours
-          help: The default expected hours for projects in this cycle.
+      usage: init [options] <hours>
     -
       name: launch
       description: Tally votes and create project teams.

--- a/config/commands/cycle.yaml
+++ b/config/commands/cycle.yaml
@@ -27,7 +27,7 @@ command:
       example: cycle init --help
       description: Get help on initializing a cycle.
     -
-      example: cycle init --hours=32
+      example: cycle init 32
       description: Initialize a cycle that expects 32 hours of work for each project.
     -
       example: cycle reflect

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@learnersguild/game-cli",
-  "version": "2.1.2",
+  "version": "2.1.3",
   "description": "Option parser for Learners Guild commands.",
   "main": "lib",
   "scripts": {


### PR DESCRIPTION
Fixes [ch2315](https://app.clubhouse.io/learnersguild/story/2315)

Depends on [PR #872 in the game repo.](https://github.com/LearnersGuild/game/pull/872)

## Overview

We simply updated the Cycle yaml file to reflect the new method for entering cycle hours.
Rather than `cycle init hours=32` it will be `cycle init 32`.

## Data Model / DB Schema Changes

None

## Environment / Configuration Changes

Updates Cycle yaml configuration file.

## Notes

The Game repo need to be up to date with PR #872 for the new command to work.
